### PR TITLE
Create cache_dir if not exists

### DIFF
--- a/library/Zend/Cache/Backend/File.php
+++ b/library/Zend/Cache/Backend/File.php
@@ -379,6 +379,9 @@ class Zend_Cache_Backend_File extends Zend_Cache_Backend implements Zend_Cache_B
      */
     public function getFillingPercentage()
     {
+        if (!\is_dir($this->_options['cache_dir'])) {
+            \mkdir($this->_options['cache_dir'], 0755, true);
+        }
         $free = disk_free_space($this->_options['cache_dir']);
         $total = disk_total_space($this->_options['cache_dir']);
         if ($total == 0) {


### PR DESCRIPTION
Fixes a problem when custom cache dir does not exists
Related to: https://github.com/magento/magento2/pull/31122